### PR TITLE
Update bedrock-stack.ts change bucket removal policy to destroy

### DIFF
--- a/healthcare-life-sciences/automate-discharge-instructions/lib/bedrock-stack.ts
+++ b/healthcare-life-sciences/automate-discharge-instructions/lib/bedrock-stack.ts
@@ -38,7 +38,7 @@ export class BedrockStack extends cdk.Stack {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       encryption: s3.BucketEncryption.S3_MANAGED,
       versioned: false,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
     });
 


### PR DESCRIPTION
the install errored with Cannot use 'autoDeleteObjects' property on a bucket without setting removal policy to 'DESTROY'. Changed bucket policy because we want to clean completely